### PR TITLE
WithPropertyHeader: extract data by header text instead of column name

### DIFF
--- a/src/EPPlus.DataExtractor/IDataExtractorInterfaces.cs
+++ b/src/EPPlus.DataExtractor/IDataExtractorInterfaces.cs
@@ -54,6 +54,53 @@ namespace EPPlus.DataExtractor
         ICollectionPropertyConfiguration<TRow> WithProperty<TValue>(Expression<Func<TRow, TValue>> propertyExpression,
             string column, Func<object, TValue> convertDataFunc, Action<PropertyExtractionContext, object> setPropertyValueCallback = null,
             Action<PropertyExtractionContext, TValue> setPropertyCastedValueCallback = null);
+
+        /// <summary>
+        /// Maps a property from the type defined as the row model
+        /// to the column identifier that has its value.
+        /// </summary>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="propertyExpression">Expression for the property to be mapped.</param>
+        /// <param name="columnHeader">Header of the column that contains the value to be mapped to
+        /// the property defined by <paramref name="propertyExpression"/>.</param>
+        /// <param name="setPropertyValueCallback">Optional callback that gets executed before retrieving the cell value casted to <typeparamref name="TValue"/>.
+        /// The first parameter contains the cell address and a method that can abort the entire execution.
+        /// The second one the value of the cell.</param>
+        /// <param name="setPropertyCastedValueCallback">Optional callback that gets executed after retrieving the cell value casted to <typeparamref name="TValue"/>.
+        /// The first parameter contains the cell address and a method that can abort the entire execution.
+        /// The second one the value of the cell.</param>
+        /// <returns></returns>
+        ICollectionPropertyConfiguration<TRow> WithPropertyHeader<TValue>(Expression<Func<TRow, TValue>> propertyExpression,
+            string columnHeader,
+            Action<PropertyExtractionContext, object> setPropertyValueCallback = null,
+            Action<PropertyExtractionContext, TValue> setPropertyCastedValueCallback = null);
+
+        /// <summary>
+        /// Maps a property from the type defined as the row model
+        /// to the column identifier that has its value.
+        /// </summary>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="propertyExpression">Expression for the property to be mapped.</param>
+        /// <param name="columnHeader">Header of the column that contains the value to be mapped to
+        /// the property defined by <paramref name="propertyExpression"/>.</param>
+        /// <param name="convertDataFunc">Function that can be used to convert the cell value, which is an object
+        /// to the desirable <typeparamref name="TValue"/>.</param>
+        /// <param name="setPropertyValueCallback">Optional callback that gets executed prior to the <paramref name="convertDataFunc"/>.
+        /// The first parameter contains the cell address and a method that can abort the entire execution.
+        /// The second one the value of the cell.</param>
+        /// <param name="validateCastedCellValue">Optional callback that gets executed after the <paramref name="convertDataFunc"/>.
+        /// The first parameter contains the cell address and a method that can abort the entire execution.
+        /// The second one the value of the cell.</param>
+        /// <returns></returns>
+        ICollectionPropertyConfiguration<TRow> WithPropertyHeader<TValue>(Expression<Func<TRow, TValue>> propertyExpression,
+            string columnHeader, Func<object, TValue> convertDataFunc, Action<PropertyExtractionContext, object> setPropertyValueCallback = null,
+            Action<PropertyExtractionContext, TValue> setPropertyCastedValueCallback = null);
+
+        /// <summary>
+        /// Sets the row which will be used to find headers.
+        /// </summary>
+        /// <param name="row">The row which will be used to find headers (1-based; default value is 1)</param>
+        ICollectionPropertyConfiguration<TRow> WithHeaderRow(int row);
     }
 
     public interface IGetData<TRow>


### PR DESCRIPTION
A feature that was convenient to me, and might be useful for others:
Instead of searching for the property by column name, search by the header text.
Example:

`   |   A         |    B   `
`1| Product | Price `
`2| Tea        | 0.9`
`3| Coffee  | 1.5`

Instead of writing 
`  .WithProperty(p=>p.Price, "B")`
it will be possible to write
` .WithHeaderRow(1) //Optional: 1 by default`
` .WithPropertyHeader(p => p.Price, "Price")`

Then, if another column gets inserted after A, moving Price to column C, no code modification will be needed.
