### PR TITLE
Fix observable collection bug

### DIFF
--- a/src/EPPlus.DataExtractor.Tests/ExpressionHelperTests.cs
+++ b/src/EPPlus.DataExtractor.Tests/ExpressionHelperTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using System.Text;
+using Xunit;
+
+namespace EPPlus.DataExtractor.Tests
+{
+    public class ExpressionHelperTests
+    {
+        class ModelWithObservableCollection
+        {
+            public ObservableCollection<string> CollectionProp { get; set; }
+        }
+
+        [Fact]
+        public void ValidatePropertyExpressionType_WithIncompatiblePropertyType_ShouldFail()
+        {
+            var collectionPropExpression = GetExpression<ModelWithObservableCollection, string>(m => m.CollectionProp);
+
+            Assert.Throws<ArgumentException>(() =>
+                ExpressionExtensions.ValidatePropertyExpressionType<ModelWithObservableCollection, string, Collection<string>>(collectionPropExpression));
+        }
+
+        class ModelWithCollection
+        {
+            public Collection<string> CollectionProp { get; set; }
+        }
+
+        [Fact]
+        public void ValidatePropertyExpressionType_WithSameCollectionPropertyType()
+        {
+            var collectionPropExpression = GetExpression<ModelWithCollection, string>(m => m.CollectionProp);
+
+            ExpressionExtensions.ValidatePropertyExpressionType<ModelWithCollection, string, Collection<string>>(collectionPropExpression);
+        }
+
+        class ModelWithList
+        {
+            public List<string> CollectionProp { get; set; }
+        }
+
+        [Fact]
+        public void ValidatePropertyExpressionType_WithSameListPropertyType()
+        {
+            var collectionPropExpression = GetExpression<ModelWithList, string>(m => m.CollectionProp);
+
+            ExpressionExtensions.ValidatePropertyExpressionType<ModelWithList, string, List<string>>(collectionPropExpression);
+        }
+
+        private static Expression<Func<TModel, Collection<TItem>>> GetExpression<TModel, TItem>(Expression<Func<TModel, Collection<TItem>>> property) => property;
+        private static Expression<Func<TModel, List<TItem>>> GetExpression<TModel, TItem>(Expression<Func<TModel, List<TItem>>> property) => property;
+    }
+}

--- a/src/EPPlus.DataExtractor.Tests/WorksheetExtensionsTests.cs
+++ b/src/EPPlus.DataExtractor.Tests/WorksheetExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using OfficeOpenXml;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -597,6 +598,51 @@ namespace EPPlus.DataExtractor.Tests
                     .GetData(2, 4);
 
                 Assert.Throws<InvalidOperationException>(() => dataEnumerable.ToList());
+            }
+        }
+
+        public class MultiLingualUserDataWithObservableCollection :
+            BaseMultiLingualUserData<ObservableCollection<string>>
+        {
+            public MultiLingualUserDataWithObservableCollection()
+            {
+                this.LanguagesSpoken = new ObservableCollection<string>();
+            }
+        }
+
+        [Fact]
+        public void ExtractSimpleDataCollection_WithObservableCollectionProperty()
+        {
+            var fileInfo = GetSpreadsheetFileInfo();
+            using (var package = new ExcelPackage(fileInfo))
+            {
+                var worksheet = package.Workbook.Worksheets["StringsCollectionWorksheet"];
+
+                var items = worksheet
+                    .Extract<MultiLingualUserDataWithObservableCollection>()
+                    .WithProperty(p => p.FirstName, "B")
+                    .WithProperty(p => p.LastName, "A")
+                    .WithCollectionProperty(x => x.LanguagesSpoken, "C", "E")
+                    // Read from row 2 to 4
+                    .GetData(2, 4)
+                    .ToList();
+
+                // 3 rows should be read.
+                Assert.Equal(3, items.Count);
+
+                // First record should have 2 languages
+                Assert.Equal(2, items[0].LanguagesSpoken.Count);
+                Assert.Contains("Spanish", items[0].LanguagesSpoken);
+                Assert.Contains("Romanian", items[0].LanguagesSpoken);
+
+                // Second record should have 3 languages
+                Assert.Equal(3, items[1].LanguagesSpoken.Count);
+                Assert.Contains("English", items[1].LanguagesSpoken);
+                Assert.Contains("Latin", items[1].LanguagesSpoken);
+                Assert.Contains("Mandarin", items[1].LanguagesSpoken);
+
+                // Third record should have no languages
+                Assert.Empty(items[2].LanguagesSpoken);
             }
         }
     }

--- a/src/EPPlus.DataExtractor.Tests/WorksheetExtensionsTests.cs
+++ b/src/EPPlus.DataExtractor.Tests/WorksheetExtensionsTests.cs
@@ -277,7 +277,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<RowDataWithColumnBeingRowWithUninitializedICollection>()
                     .WithProperty(p => p.Name, "F")
                     .WithProperty(p => p.Age, "G")
-                    .WithCollectionProperty(p => p.MoneyData,
+                    .WithInitializedCollectionProperty(p => p.MoneyData,
                         item => item.Date, 1,
                         item => item.ReceivedMoney, "H", "S")
                     .GetData(2, 4);
@@ -296,7 +296,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<RowDataWithColumnBeingRowWithInitializedICollection>()
                     .WithProperty(p => p.Name, "F")
                     .WithProperty(p => p.Age, "G")
-                    .WithCollectionProperty(p => p.MoneyData,
+                    .WithInitializedCollectionProperty(p => p.MoneyData,
                         item => item.Date, 1,
                         item => item.ReceivedMoney, "H", "S")
                     .GetData(2, 4)
@@ -450,7 +450,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<CarDealerBranch.CarDealerBranchRevenueWithICollection>()
                     .WithProperty(p => p.BranchName, "A")
                     .WithProperty(p => p.BranchLocation, "B")
-                    .WithCollectionProperty(p => p.RevenueByMonth,
+                    .WithInitializedCollectionProperty(p => p.RevenueByMonth,
                         1,
                         "C",
                         cfg => cfg
@@ -497,7 +497,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<CarDealerBranch.CarDealerBranchRevenueWithUninitializedICollection>()
                     .WithProperty(p => p.BranchName, "A")
                     .WithProperty(p => p.BranchLocation, "B")
-                    .WithCollectionProperty(p => p.RevenueByMonth,
+                    .WithInitializedCollectionProperty(p => p.RevenueByMonth,
                         1,
                         "C",
                         cfg => cfg
@@ -557,7 +557,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<MultiLingualUserDataWithICollection>()
                     .WithProperty(p => p.FirstName, "B")
                     .WithProperty(p => p.LastName, "A")
-                    .WithCollectionProperty(x => x.LanguagesSpoken, "C", "E")
+                    .WithInitializedCollectionProperty(x => x.LanguagesSpoken, "C", "E")
                     // Read from row 2 to 4
                     .GetData(2, 4)
                     .ToList();
@@ -593,7 +593,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<MultiLingualUserDataWithUnintializedICollection>()
                     .WithProperty(p => p.FirstName, "B")
                     .WithProperty(p => p.LastName, "A")
-                    .WithCollectionProperty(x => x.LanguagesSpoken, "C", "E")
+                    .WithInitializedCollectionProperty(x => x.LanguagesSpoken, "C", "E")
                     // Read from row 2 to 4
                     .GetData(2, 4);
 
@@ -611,6 +611,24 @@ namespace EPPlus.DataExtractor.Tests
         }
 
         [Fact]
+        public void ExtractSimpleDataCollection_WithObservableCollectionPropertyInCollectionOverload_ShouldFail()
+        {
+            var fileInfo = GetSpreadsheetFileInfo();
+            using (var package = new ExcelPackage(fileInfo))
+            {
+                var worksheet = package.Workbook.Worksheets["StringsCollectionWorksheet"];
+
+                var dataExtractorSetup = worksheet
+                    .Extract<MultiLingualUserDataWithObservableCollection>()
+                    .WithProperty(p => p.FirstName, "B")
+                    .WithProperty(p => p.LastName, "A");
+
+                Assert.Throws<ArgumentException>(() =>
+                    dataExtractorSetup.WithCollectionProperty(p => p.LanguagesSpoken, "C", "E"));
+            }
+        }
+
+        [Fact]
         public void ExtractSimpleDataCollection_WithObservableCollectionProperty()
         {
             var fileInfo = GetSpreadsheetFileInfo();
@@ -622,7 +640,7 @@ namespace EPPlus.DataExtractor.Tests
                     .Extract<MultiLingualUserDataWithObservableCollection>()
                     .WithProperty(p => p.FirstName, "B")
                     .WithProperty(p => p.LastName, "A")
-                    .WithCollectionProperty(x => x.LanguagesSpoken, "C", "E")
+                    .WithInitializedCollectionProperty(x => x.LanguagesSpoken, "C", "E")
                     // Read from row 2 to 4
                     .GetData(2, 4)
                     .ToList();

--- a/src/EPPlus.DataExtractor/DataExtractor.cs
+++ b/src/EPPlus.DataExtractor/DataExtractor.cs
@@ -32,6 +32,19 @@ namespace EPPlus.DataExtractor
             this.simpleCollectionColumnSetters = new List<ISimpleCollectionColumnDataExtractor<TRow>>();
         }
 
+        private static void ValidateColumn(string column, string propertyName)
+        {
+            var argumentName = propertyName ?? nameof(column);
+            if (string.IsNullOrWhiteSpace(column))
+            {
+                throw new ArgumentException("The column value must be a valid non empty string containing letters.", argumentName);
+            }
+            if (!DataExtractor.ColumnRegex.IsMatch(column))
+            {
+                throw new ArgumentException("The column value must contain only letters.", argumentName);
+            }
+        }
+
         /// <summary>
         /// Maps a property from the type defined as the row model
         /// to the column identifier that has its value.
@@ -79,7 +92,7 @@ namespace EPPlus.DataExtractor
         {
             if (propertyExpression == null)
                 throw new ArgumentNullException(nameof(propertyExpression));
-            if(string.IsNullOrWhiteSpace(column))
+            if (string.IsNullOrWhiteSpace(column))
                 throw new ArgumentNullException(nameof(column));
             if (!DataExtractor.ColumnRegex.IsMatch(column))
                 throw new ArgumentException("The column value must contain only letters.", nameof(column));
@@ -112,6 +125,11 @@ namespace EPPlus.DataExtractor
         /// <returns>Returns an <see cref="IEnumerable{T}"/> with the data of the columns.</returns>
         public IEnumerable<TRow> GetData(int fromRow, Predicate<int> @while)
         {
+            if (@while is null)
+            {
+                throw new ArgumentNullException(nameof(@while));
+            }
+
             for (int row = fromRow; @while(row); row++)
             {
                 var dataInstance = new TRow();
@@ -140,6 +158,15 @@ namespace EPPlus.DataExtractor
             Expression<Func<TRow, List<TCollectionItem>>> propertyCollection,
             string startColumn, string endColumn) where TCollectionItem : class
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, List<TCollectionItem>>();
             var collectionConfiguration = new SimpleNewableCollectionColumnDataExtractor<TRow, List<TCollectionItem>, TCollectionItem>
                 (propertyCollection, startColumn, endColumn);
 
@@ -152,6 +179,15 @@ namespace EPPlus.DataExtractor
             Expression<Func<TRow, HashSet<TCollectionItem>>> propertyCollection,
             string startColumn, string endColumn) where TCollectionItem : class
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, HashSet<TCollectionItem>>();
             var collectionConfiguration = new SimpleNewableCollectionColumnDataExtractor<TRow, HashSet<TCollectionItem>, TCollectionItem>
                 (propertyCollection, startColumn, endColumn);
 
@@ -164,6 +200,16 @@ namespace EPPlus.DataExtractor
             Expression<Func<TRow, Collection<TCollectionItem>>> propertyCollection,
             string startColumn, string endColumn) where TCollectionItem : class
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, Collection<TCollectionItem>>();
+
             var collectionConfiguration = new SimpleNewableCollectionColumnDataExtractor<TRow, Collection<TCollectionItem>, TCollectionItem>
                 (propertyCollection, startColumn, endColumn);
 
@@ -174,8 +220,22 @@ namespace EPPlus.DataExtractor
 
         public ICollectionPropertyConfiguration<TRow> WithCollectionProperty<TCollectionItem>(
             Func<TRow, ICollection<TCollectionItem>> propertyCollection,
+            string startColumn, string endColumn)
+            where TCollectionItem : class
+            => this.WithInitializedCollectionProperty(propertyCollection, startColumn, endColumn);
+
+        public ICollectionPropertyConfiguration<TRow> WithInitializedCollectionProperty<TCollectionItem>(
+            Func<TRow, ICollection<TCollectionItem>> propertyCollection,
             string startColumn, string endColumn) where TCollectionItem : class
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
             var collectionConfiguration = new SimpleCollectionColumnDataExtractor<TRow, ICollection<TCollectionItem>, TCollectionItem>
                 (propertyCollection, startColumn, endColumn);
 
@@ -190,6 +250,25 @@ namespace EPPlus.DataExtractor
             Expression<Func<TCollectionItem, TRowValue>> rowProperty,
             string startColumn, string endColumn) where TCollectionItem : class, new()
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+
+            if (headerProperty is null)
+            {
+                throw new ArgumentNullException(nameof(headerProperty));
+            }
+
+            if (rowProperty is null)
+            {
+                throw new ArgumentNullException(nameof(rowProperty));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, List<TCollectionItem>>();
             var collectionConfiguration = new NewableCollectionColumnDataExtractor<TRow, List<TCollectionItem>, TCollectionItem, THeaderValue, TRowValue>
                 (propertyCollection, headerProperty, headerRow, rowProperty, startColumn, endColumn);
 
@@ -204,6 +283,24 @@ namespace EPPlus.DataExtractor
             Expression<Func<TCollectionItem, TRowValue>> rowProperty,
             string startColumn, string endColumn) where TCollectionItem : class, new()
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+            if (headerProperty is null)
+            {
+                throw new ArgumentNullException(nameof(headerProperty));
+            }
+
+            if (rowProperty is null)
+            {
+                throw new ArgumentNullException(nameof(rowProperty));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, HashSet<TCollectionItem>>();
             var collectionConfiguration = new NewableCollectionColumnDataExtractor<TRow, HashSet<TCollectionItem>, TCollectionItem, THeaderValue, TRowValue>
                 (propertyCollection, headerProperty, headerRow, rowProperty, startColumn, endColumn);
 
@@ -218,6 +315,25 @@ namespace EPPlus.DataExtractor
             Expression<Func<TCollectionItem, TRowValue>> rowProperty,
             string startColumn, string endColumn) where TCollectionItem : class, new()
         {
+            if (propertyCollection is null)
+            {
+                throw new ArgumentNullException(nameof(propertyCollection));
+            }
+            if (headerProperty is null)
+            {
+                throw new ArgumentNullException(nameof(headerProperty));
+            }
+
+            if (rowProperty is null)
+            {
+                throw new ArgumentNullException(nameof(rowProperty));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, Collection<TCollectionItem>>();
+
             var collectionConfiguration = new NewableCollectionColumnDataExtractor<TRow, Collection<TCollectionItem>, TCollectionItem, THeaderValue, TRowValue>
                 (propertyCollection, headerProperty, headerRow, rowProperty, startColumn, endColumn);
 
@@ -234,7 +350,35 @@ namespace EPPlus.DataExtractor
             string startColumn,
             string endColumn)
             where TCollectionItem : class, new()
+            => this.WithInitializedCollectionProperty(collectionGetter, headerProperty, headerRow, rowProperty, startColumn, endColumn);
+
+        public ICollectionPropertyConfiguration<TRow> WithInitializedCollectionProperty<TCollectionItem, THeaderValue, TRowValue>(
+            Func<TRow, ICollection<TCollectionItem>> collectionGetter,
+            Expression<Func<TCollectionItem, THeaderValue>> headerProperty,
+            int headerRow,
+            Expression<Func<TCollectionItem, TRowValue>> rowProperty,
+            string startColumn,
+            string endColumn)
+            where TCollectionItem : class, new()
         {
+            if (collectionGetter is null)
+            {
+                throw new ArgumentNullException(nameof(collectionGetter));
+            }
+
+            if (headerProperty is null)
+            {
+                throw new ArgumentNullException(nameof(headerProperty));
+            }
+
+            if (rowProperty is null)
+            {
+                throw new ArgumentNullException(nameof(rowProperty));
+            }
+
+            ValidateColumn(startColumn, nameof(startColumn));
+            ValidateColumn(endColumn, nameof(endColumn));
+
             var collectionConfiguration = new CollectionColumnDataExtractor<TRow, ICollection<TCollectionItem>, TCollectionItem, THeaderValue, TRowValue>
                 (collectionGetter, headerProperty, headerRow, rowProperty, startColumn, endColumn);
 
@@ -269,8 +413,14 @@ namespace EPPlus.DataExtractor
         {
             if (propertyCollection == null)
                 throw new ArgumentNullException(nameof(propertyCollection));
-            if (configurePropertiesAction == null)
-                throw new ArgumentNullException(nameof(configurePropertiesAction));
+            if (startingColumn is null)
+            {
+                throw new ArgumentNullException(nameof(startingColumn));
+            }
+
+            ValidateColumn(startingColumn, nameof(startingColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, List<TCollectionItem>>();
 
             var columnToCollectionConfiguration = new ColumnToCollectionConfiguration<TCollectionItem>();
             configurePropertiesAction(columnToCollectionConfiguration);
@@ -310,6 +460,10 @@ namespace EPPlus.DataExtractor
                 throw new ArgumentNullException(nameof(propertyCollection));
             if (configurePropertiesAction == null)
                 throw new ArgumentNullException(nameof(configurePropertiesAction));
+            
+            ValidateColumn(startingColumn, nameof(startingColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, HashSet<TCollectionItem>>();
 
             var columnToCollectionConfiguration = new ColumnToCollectionConfiguration<TCollectionItem>();
             configurePropertiesAction(columnToCollectionConfiguration);
@@ -350,6 +504,10 @@ namespace EPPlus.DataExtractor
             if (configurePropertiesAction == null)
                 throw new ArgumentNullException(nameof(configurePropertiesAction));
 
+            ValidateColumn(startingColumn, nameof(startingColumn));
+
+            propertyCollection.ValidatePropertyExpressionType<TRow, TCollectionItem, Collection<TCollectionItem>>();
+
             var columnToCollectionConfiguration = new ColumnToCollectionConfiguration<TCollectionItem>();
             configurePropertiesAction(columnToCollectionConfiguration);
 
@@ -366,11 +524,21 @@ namespace EPPlus.DataExtractor
             string startingColumn,
             Action<IColumnToCollectionConfiguration<TCollectionItem>> configurePropertiesAction)
             where TCollectionItem : class, new()
+            => this.WithInitializedCollectionProperty(collectionGetter, headerRow, startingColumn, configurePropertiesAction);
+
+        public ICollectionPropertyConfigurationWithoutColumnsToCollection<TRow> WithInitializedCollectionProperty<TCollectionItem>(
+            Func<TRow, ICollection<TCollectionItem>> collectionGetter,
+            int headerRow,
+            string startingColumn,
+            Action<IColumnToCollectionConfiguration<TCollectionItem>> configurePropertiesAction)
+            where TCollectionItem : class, new()
         {
             if (collectionGetter == null)
                 throw new ArgumentNullException(nameof(collectionGetter));
             if (configurePropertiesAction == null)
                 throw new ArgumentNullException(nameof(configurePropertiesAction));
+
+            ValidateColumn(startingColumn, nameof(startingColumn));
 
             var columnToCollectionConfiguration = new ColumnToCollectionConfiguration<TCollectionItem>();
             configurePropertiesAction(columnToCollectionConfiguration);

--- a/src/EPPlus.DataExtractor/EPPlus.DataExtractor.csproj
+++ b/src/EPPlus.DataExtractor/EPPlus.DataExtractor.csproj
@@ -31,6 +31,10 @@ A subsequent version will be targeting multiple platforms.</PackageReleaseNotes>
   
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="4.5.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />

--- a/src/EPPlus.DataExtractor/ExpressionHelper.cs
+++ b/src/EPPlus.DataExtractor/ExpressionHelper.cs
@@ -18,7 +18,8 @@ namespace EPPlus.DataExtractor
             return setPropActionExpression.Compile();
         }
 
-        internal static void ValidatePropertyExpressionType<TModel, TCollectionItem, TCollectionProperty>(Expression<Func<TModel, TCollectionProperty>> collectionPropertyExpr)
+        internal static void ValidatePropertyExpressionType<TModel, TCollectionItem, TCollectionProperty>(
+            this Expression<Func<TModel, TCollectionProperty>> collectionPropertyExpr)
             where TCollectionProperty : class, ICollection<TCollectionItem>, new()
         {
             var expectedType = typeof(TCollectionProperty);
@@ -55,7 +56,7 @@ namespace EPPlus.DataExtractor
                         return mExpression;
                 }
 
-                throw new ArgumentException();
+                throw new ArgumentException("The expression property is not of a valid type. Ensure the expression points to a property member in the model i.e. 'm => m.MyProperty'.");
             }
         }
     }

--- a/src/EPPlus.DataExtractor/ExpressionHelper.cs
+++ b/src/EPPlus.DataExtractor/ExpressionHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace EPPlus.DataExtractor
 {
@@ -14,6 +16,47 @@ namespace EPPlus.DataExtractor
                 propertyExpression.Parameters[0], parameter);
 
             return setPropActionExpression.Compile();
+        }
+
+        internal static void ValidatePropertyExpressionType<TModel, TCollectionItem, TCollectionProperty>(Expression<Func<TModel, TCollectionProperty>> collectionPropertyExpr)
+            where TCollectionProperty : class, ICollection<TCollectionItem>, new()
+        {
+            var expectedType = typeof(TCollectionProperty);
+            if (!expectedType.IsGenericType)
+            {
+                throw new ArgumentException($"The collection property must be a generic type. Given type: {expectedType.FullName}");
+            }
+            expectedType = expectedType.GetGenericTypeDefinition();
+
+            var memberExpression = GetMemberExpression();
+            var propertyInfo = memberExpression.Member as PropertyInfo;
+            
+            var propertyType = propertyInfo.PropertyType;
+            if (!propertyType.IsGenericType)
+            {
+                throw new ArgumentException($"The property for the given collection expression must be of generic type {expectedType}.");
+            }
+            var genericCollectionType = propertyType.GetGenericTypeDefinition();
+            if (expectedType != genericCollectionType)
+            {
+                throw new ArgumentException($"The property for the given collection expression must be of type {expectedType.FullName}. Given type: {genericCollectionType.FullName}");
+            }
+
+
+            MemberExpression GetMemberExpression()
+            {
+                switch (collectionPropertyExpr.Body)
+                {
+                    case UnaryExpression unaryExpression:
+                        if (unaryExpression.Operand is MemberExpression)
+                            return (MemberExpression)unaryExpression.Operand;
+                        break;
+                    case MemberExpression mExpression:
+                        return mExpression;
+                }
+
+                throw new ArgumentException();
+            }
         }
     }
 }

--- a/src/EPPlus.DataExtractor/ICollectionPropertyConfiguration.cs
+++ b/src/EPPlus.DataExtractor/ICollectionPropertyConfiguration.cs
@@ -105,7 +105,34 @@ namespace EPPlus.DataExtractor
         /// <param name="startColumn">The start of the column that will be extract to the collection.</param>
         /// <param name="endColumn">The start of the column that will be extract to the collection.</param>
         /// <returns></returns>
+        [Obsolete("Use the method " + nameof(WithInitializedCollectionProperty) + " instead and ensure the collection property is initialized", true)]
         ICollectionPropertyConfiguration<TRow> WithCollectionProperty<TCollectionItem, THeaderValue, TRowValue>(
+            Func<TRow, ICollection<TCollectionItem>> collectionGetter,
+            Expression<Func<TCollectionItem, THeaderValue>> headerProperty, int headerRow,
+            Expression<Func<TCollectionItem, TRowValue>> rowProperty,
+            string startColumn, string endColumn)
+            where TCollectionItem : class, new();
+
+        /// <summary>
+        /// Configure a collection property from <typeparamref name="TRow"/> object
+        /// that will be populated by columns data, instead of rows.
+        /// </summary>
+        /// <typeparam name="TCollectionItem">The type used inside a collection.
+        /// This type will usually have two properties, one to hold the column header and another
+        /// one for the row value.</typeparam>
+        /// <typeparam name="THeaderValue">The type of the header column.</typeparam>
+        /// <typeparam name="TRowValue">The type of the row value.</typeparam>
+        /// <param name="collectionGetter">Function used to obtain the instance of collection where the
+        /// new values will be added.</param>
+        /// <param name="headerProperty">The expression property from <typeparamref name="TCollectionItem"/>
+        /// indicating the property that will be populated with the header value.</param>
+        /// <param name="headerRow">The row number that contains the header data.</param>
+        /// <param name="rowProperty">>The expression property from <typeparamref name="TCollectionItem"/>
+        /// indicating the property that will be populated with the row value.</param>
+        /// <param name="startColumn">The start of the column that will be extract to the collection.</param>
+        /// <param name="endColumn">The start of the column that will be extract to the collection.</param>
+        /// <returns></returns>
+        ICollectionPropertyConfiguration<TRow> WithInitializedCollectionProperty<TCollectionItem, THeaderValue, TRowValue>(
             Func<TRow, ICollection<TCollectionItem>> collectionGetter,
             Expression<Func<TCollectionItem, THeaderValue>> headerProperty, int headerRow,
             Expression<Func<TCollectionItem, TRowValue>> rowProperty,
@@ -205,7 +232,32 @@ namespace EPPlus.DataExtractor
         /// to define the mappings of the columns.
         /// </param>
         /// <returns></returns>
+        [Obsolete("Use the method " + nameof(WithInitializedCollectionProperty) + " instead and ensure the collection property is initialized", true)]
         ICollectionPropertyConfigurationWithoutColumnsToCollection<TRow> WithCollectionProperty<TCollectionItem>(
+            Func<TRow, ICollection<TCollectionItem>> collectionGetter,
+            int headerRow,
+            string startingColumn,
+            Action<IColumnToCollectionConfiguration<TCollectionItem>> configurePropertiesAction)
+            where TCollectionItem : class, new();
+
+        /// <summary>
+        /// Configures a collection property to unpivot multiple columns to items in the collection property.
+        /// Different from the overloads, this method allows for having an undefined amount of columns
+        /// to be unpivoted to the collection.
+        /// </summary>
+        /// <param name="collectionGetter">Function used to obtain the instance of collection where the
+        /// new values will be added.</param>
+        /// <param name="headerRow">The number of the row where the header is defined. This row will be used
+        /// to search for the text of the collection columns mapping.</param>
+        /// <param name="startingColumn">Indicates the column address (with letters) where this collection
+        /// starts.</param>
+        /// <param name="configurePropertiesAction">Action to be used to configure the columns
+        /// for the collection items. Use the method
+        /// <see cref="IColumnToCollectionConfiguration.WithColumn{TRowValue}(Expression{Func{TCollectionItem, TRowValue}}, string)"/>
+        /// to define the mappings of the columns.
+        /// </param>
+        /// <returns></returns>
+        ICollectionPropertyConfigurationWithoutColumnsToCollection<TRow> WithInitializedCollectionProperty<TCollectionItem>(
             Func<TRow, ICollection<TCollectionItem>> collectionGetter,
             int headerRow,
             string startingColumn,
@@ -272,7 +324,24 @@ namespace EPPlus.DataExtractor
         /// <param name="startColumn">The start of the column that will be extract to the collection.</param>
         /// <param name="endColumn">The start of the column that will be extract to the collection.</param>
         /// <returns></returns>
+        [Obsolete("Use the method "+ nameof(WithInitializedCollectionProperty) + " instead and ensure the collection property is initialized", true)]
         ICollectionPropertyConfiguration<TRow> WithCollectionProperty<TCollectionItem>(
+            Func<TRow, ICollection<TCollectionItem>> collectionGetter,
+            string startColumn, string endColumn) where TCollectionItem : class;
+
+        /// <summary>
+        /// Configure a collection property from <typeparamref name="TRow"/> object
+        /// that will be populated by columns data, instead of rows.
+        /// </summary>
+        /// <typeparam name="TCollectionItem">The type used inside a collection.
+        /// This type will usually have two properties, one to hold the column header and another
+        /// one for the row value.</typeparam>
+        /// <param name="collectionGetter">Function used to obtain the instance of collection where the
+        /// new values will be added.</param>
+        /// <param name="startColumn">The start of the column that will be extract to the collection.</param>
+        /// <param name="endColumn">The start of the column that will be extract to the collection.</param>
+        /// <returns></returns>
+        ICollectionPropertyConfiguration<TRow> WithInitializedCollectionProperty<TCollectionItem>(
             Func<TRow, ICollection<TCollectionItem>> collectionGetter,
             string startColumn, string endColumn) where TCollectionItem : class;
     }


### PR DESCRIPTION
This PR contains breaking changes. This PR fixes #21 for ObservableCollection

### Breaking change
`WithCollectionProperty` accepting ICollection as the expression property for the model are now **obsolete**. If your collection property does not fit any of the other overloads (it is not a `List<T>`, `HashSet<T>` or `Collection<T>`), ensure that the property is **already initialized** and use the method `WithInitializedCollectionProperty` instead.

### Other changes
- The `WithCollectionProperty` methods now ensure that the collection property is of the exact same type of the expected collection. So if you're using the `WithCollectionProperty` overload that expects a collection property of `Collection<T>`, your model **must** have its collection property as a `Collection<T>`. If the property is of type `ObservableCollection<T>`, for example, which inherits from `Collection<T>`, an error will be thrown at runtime. For such cases, the `WithInitializedCollectionProperty` must be used instead.